### PR TITLE
feat: Add --dry-run option to batch command

### DIFF
--- a/tests/cli/test_batch.py
+++ b/tests/cli/test_batch.py
@@ -138,3 +138,31 @@ class TestBatchCommand:
 
         assert result.exit_code == 0
         assert "300" in result.stdout
+
+    def test_batch_dry_run(self, cli_runner, sample_batch_files):
+        """Test batch processing dry-run mode."""
+        batch_dir, files = sample_batch_files
+
+        result = cli_runner.invoke(app, [
+            "batch", str(batch_dir),
+            "--dry-run"
+        ])
+
+        assert result.exit_code == 0
+        assert "Would process" in result.stdout
+        assert "Total:" in result.stdout
+
+    def test_batch_mutually_exclusive_flags(self, cli_runner, tmp_path):
+        """Test that --auto-continue and --auto-stop cannot be used together."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        
+        result = cli_runner.invoke(app, [
+            "batch", 
+            str(input_dir), 
+            "--auto-continue", 
+            "--auto-stop"
+        ])
+        
+        assert result.exit_code != 0
+        assert "Cannot use both --auto-continue and --auto-stop" in result.stdout


### PR DESCRIPTION
feat: Add --dry-run option to batch command

### Description
This PR adds a `--dry-run` (alias `-n`) option to the `batch` command. This allows users to preview the files that would be processed and their total size without actually executing the chunking pipeline.

This PR also fixes a regression in `src/core/cli/app.py` where the `batch` command exposed via the CLI was missing several arguments (including `strategy`, `max-tokens`, `save-history`, etc.) compared to the underlying `batch_command` implementation. This mismatch was causing CLI usage errors and test failures.

### Changes Made
-   **src/core/cli/commands/batch.py**:
    -   Added `dry_run` parameter to `batch_command`.
    -   Implemented logic to list discovered files and their sizes, then exit if `dry_run` is active.
    -   Imported `humanfriendly` for readable file size formatting.
-   **src/core/cli/app.py**:
    -   Updated `batch` command signature to include `dry_run`.
    -   **Fix:** Restored missing parameters (`strategy`, `max_tokens`, `overlap`, `output`, `single_file`, `recursive`, `advanced_ocr`, `auto_stop`, `auto_skip`, `save_history`) that were present in `batch_command` but missing in the Typer wrapper.
    -   **Fix:** Renamed `input_dir` argument back to `directory` to align with `batch.py` and existing tests.
    -   **Fix:** Added mutual exclusivity validation for `--auto-continue` and `--auto-stop` flags to prevent ambiguous behavior.

### Verification
-   **Reproduction:** Created a script to verify `--dry-run` lists files and exits without processing.
-   **Tests:** Ran `pytest tests/cli/test_batch.py` and `tests/e2e/test_cli_batch_retry.py`. All 22 relevant tests passed.
-   **Validation:** Verified that using both `--auto-continue` and `--auto-stop` raises a clear error.
-   **Manual Check:** Verified the output matches the expected behavior:
    ```
    Would process 2 files:
      ├── test1.txt (11 bytes)
      └── test2.txt (12 bytes)
    Total: 2 files, 23 bytes
    ```

Closes #3
