### PR TITLE
Add global quiet and verbose flags

### DIFF
--- a/src/core/cli/app.py
+++ b/src/core/cli/app.py
@@ -1,8 +1,10 @@
 """ragctl CLI Application (Typer-based)."""
+import logging
 import warnings
 import typer
 from pathlib import Path
 from typing_extensions import Annotated
+from src.core.cli.utils.display import set_verbosity
 
 # Suppress common warnings for better UX
 warnings.filterwarnings("ignore", category=FutureWarning, module="transformers")
@@ -44,12 +46,27 @@ def main(
     version: Annotated[
         bool,
         typer.Option(
-            "--version", "-v",
+            "--version", "-V",
             help="Show version and exit",
             callback=version_callback,
             is_eager=True
         )
     ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet", "-q",
+            help="Quiet mode: errors only"
+        )
+    ] = False,
+    verbose: Annotated[
+        int,
+        typer.Option(
+            "--verbose", "-v",
+            help="Increase verbosity (-v for info/debug, -vv for full details)",
+            count=True
+        )
+    ] = 0,
 ):
     """
     RAG Studio - Production-ready RAG toolkit with intelligent document processing.
@@ -83,7 +100,19 @@ def main(
     Support:
         Report issues at: https://github.com/datallmhub/ragctl/issues
     """
-    pass
+    if quiet and verbose > 0:
+        raise typer.BadParameter("Cannot use --quiet with --verbose/--vv")
+
+    logging_level = logging.WARNING
+    if quiet:
+        logging_level = logging.ERROR
+    elif verbose >= 2:
+        logging_level = logging.DEBUG
+    elif verbose == 1:
+        logging_level = logging.INFO
+
+    logging.basicConfig(level=logging_level, force=True)
+    set_verbosity(level=verbose, quiet=quiet)
 
 
 # Register commands - imports happen inside each command function (lazy loading)

--- a/src/core/cli/utils/display.py
+++ b/src/core/cli/utils/display.py
@@ -1,14 +1,26 @@
 """Display utilities for CLI using Rich."""
+from typing import List, Dict, Any
 from rich.console import Console
 from rich.table import Table
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
-from typing import List, Dict, Any
 
 console = Console()
+_verbosity_level = 0
+_quiet_mode = False
+
+
+def set_verbosity(level: int = 0, quiet: bool = False) -> None:
+    """Configure display verbosity and quiet mode."""
+    global _verbosity_level, _quiet_mode, console
+    _verbosity_level = level
+    _quiet_mode = quiet
+    console = Console(quiet=quiet)
 
 
 def print_success(message: str) -> None:
     """Print success message."""
+    if _quiet_mode:
+        return
     console.print(f"[green]✓[/green] {message}")
 
 
@@ -19,11 +31,15 @@ def print_error(message: str) -> None:
 
 def print_warning(message: str) -> None:
     """Print warning message."""
+    if _quiet_mode:
+        return
     console.print(f"[yellow]⚠[/yellow] {message}")
 
 
 def print_info(message: str) -> None:
     """Print info message."""
+    if _quiet_mode:
+        return
     console.print(f"[cyan]ℹ[/cyan] {message}")
 
 
@@ -61,12 +77,15 @@ def create_batch_progress() -> Progress:
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         TaskProgressColumn(),
-        console=console
+        console=console,
+        disable=_quiet_mode,
     )
 
 
 def display_stats(stats: Dict[str, Any]) -> None:
     """Display statistics in a formatted way."""
+    if _quiet_mode:
+        return
     table = Table(show_header=False, box=None)
     table.add_column("Metric", style="cyan", no_wrap=True)
     table.add_column("Value", style="white")


### PR DESCRIPTION
## Summary
- add global CLI quiet/verbose flags so users can choose errors-only or more detailed output
- wire verbosity into logging and display helpers to suppress non-error prints when quiet is enabled

## Changes
- introduce -q/--quiet and counted -v/--verbose flags (with -V for version) at the root Typer app
- configure logging levels based on flags and pass settings to display utilities
- update display utilities to honor quiet mode and disable progress output when quiet

Fixes #5